### PR TITLE
Avoid encoding numeric values as datetime

### DIFF
--- a/jsondatetime/jsondatetime.py
+++ b/jsondatetime/jsondatetime.py
@@ -1,3 +1,4 @@
+import six
 import json
 import datetime
 import dateutil.parser
@@ -16,24 +17,27 @@ class DatetimeJSONEncoder(json.JSONEncoder):
         if isinstance(obj, datetime.datetime) or isinstance(obj, datetime.date):
             return obj.isoformat()
         else:
-            return json.JSONEncoder.default(obj)
+            return json.JSONEncoder().default(obj)
 
-json._default_encoder = DatetimeJSONEncoder
+json._default_encoder = DatetimeJSONEncoder()
 
 
 def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True,
           allow_nan=True, cls=None, indent=None, separators=None,
           encoding='utf-8', default=None, sort_keys=False, **kw):
+    if six.PY2:
+        kw.update({"encoding": encoding})
     return json.dumps(obj, skipkeys=skipkeys, ensure_ascii=ensure_ascii,
                       check_circular=check_circular, allow_nan=allow_nan,
-                      cls=cls, indent=indent, separators=None, encoding=encoding,
+                      cls=cls, indent=indent, separators=separators,
                       default=default, sort_keys=sort_keys, **kw)
 
-def loads(s, **kwargs):
 
+def loads(s, **kwargs):
     source = json.loads(s, **kwargs)
 
     return iteritems(source)
+
 
 def iteritems(source):
 
@@ -43,10 +47,15 @@ def iteritems(source):
                 iteritems(a)
         elif isinstance(v, dict):
             iteritems(v)
-        elif isinstance(v, string_types):
+        elif isinstance(v, string_types) and not v.isdigit():
+            try:
+                float(v)
+                continue
+            except ValueError:
+                pass
             try:
                 source[k] = dateutil.parser.parse(v, ignoretz=True)
-            except:
+            except (ValueError, OverflowError):
                 pass
 
     return source

--- a/jsondatetime/tests/test_jsondatetime.py
+++ b/jsondatetime/tests/test_jsondatetime.py
@@ -40,6 +40,18 @@ class TestBase(TestCase):
         self.assertIs(type(decoded), datetime.datetime)
         self.assertEqual(decoded, self.expected)
 
+    def test_numeric_value(self):
+        decoded = json.loads('{"key": "2"}')
+        self.assertEqual(decoded.get('key'), "2")
+
+    def test_float_value(self):
+        decoded = json.loads('{"key": "2.5"}')
+        self.assertEqual(decoded.get('key'), "2.5")
+
+    def test_json_dumps(self):
+        json.dumps({"x": 1})
+
+
     def hook(self, dct):
         dct["hookjob"] = "I'm hooked!"
         return dct


### PR DESCRIPTION
1. In case numeric value is provided as a str, i.e. "2", we don't want to convert it to datetime. Same for float value, i.e. 8.5
2. Add python3 support for json.dumps